### PR TITLE
Allow hash primitives as arguments

### DIFF
--- a/lib/async_cache/store.rb
+++ b/lib/async_cache/store.rb
@@ -109,6 +109,7 @@ module AsyncCache
           next if argument.is_a? Numeric
           next if argument.is_a? String
           next if argument.is_a? Symbol
+          next if argument.is_a? Hash
 
           raise ArgumentError, "Cannot send complex data for block argument #{index + 1}: #{argument.class.name}"
         end


### PR DESCRIPTION
Does what it says on the tin. Ruby hashes serialize easily to JSON and Sidekiq is more than happy to receive them.
