### PR TITLE
Add queue clearing task and Railtie

### DIFF
--- a/lib/async_cache.rb
+++ b/lib/async_cache.rb
@@ -21,3 +21,4 @@ end
 require 'async_cache/version'
 require 'async_cache/store'
 require 'async_cache/workers/base'
+require 'async_cache/railtie' if defined?(Rails)

--- a/lib/async_cache/railtie.rb
+++ b/lib/async_cache/railtie.rb
@@ -1,0 +1,11 @@
+module AsyncCache
+  class Railtie < ::Rails::Railtie
+    rake_tasks do
+      %w[clear].each do |name|
+        file = File.join(File.dirname(__FILE__), "tasks/#{name}.rake")
+
+        load file
+      end
+    end
+  end
+end

--- a/lib/async_cache/store.rb
+++ b/lib/async_cache/store.rb
@@ -123,6 +123,18 @@ module AsyncCache
       )
     end
 
+    def inspect
+      pointer_format  = '0x%014x'
+      pointer         = Kernel.sprintf pointer_format, self.object_id * 2
+      backend_pointer = Kernel.sprintf pointer_format, @backend.object_id * 2
+
+      '#<' + [
+        "#{self.class.name}:#{pointer} ",
+        "@worker_klass=#{@worker_klass.name}, ",
+        "@backend=#<#{@backend.class.name}:#{backend_pointer}>"
+      ].join('') + '>'
+    end
+
     private
 
       # Ensures the arguments are primitives.

--- a/lib/async_cache/store.rb
+++ b/lib/async_cache/store.rb
@@ -2,6 +2,11 @@ module AsyncCache
   class Store
     attr_accessor :backend, :worker_klass
 
+    # Global index of store instances
+    def self.stores
+      @stores ||= []
+    end
+
     # @param [Hash] opts Initialization options
     # @option opts [Object] :backend The backend that it will read/write
     #   entries to/from
@@ -19,6 +24,9 @@ module AsyncCache
         end
 
       @backend = opts[:backend] || AsyncCache.backend
+
+      # Register ourselves in the array of known store instances
+      self.class.stores << self
     end
 
     # @param [String] locator The constant locator for the entry in the cache
@@ -64,6 +72,10 @@ module AsyncCache
       when :current
         return cached_data
       end
+    end
+
+    def clear
+      @worker_klass.clear
     end
 
     def determine_strategy(has_cached_data:, needs_regen:, synchronous_regen:)

--- a/lib/async_cache/tasks/clear.rake
+++ b/lib/async_cache/tasks/clear.rake
@@ -1,0 +1,8 @@
+namespace :async_cache do
+  desc 'Clear the worker queues'
+  task :clear do
+    AsyncCache::Store.stores.each do |store|
+      store.clear
+    end
+  end
+end

--- a/lib/async_cache/tasks/clear.rake
+++ b/lib/async_cache/tasks/clear.rake
@@ -1,8 +1,16 @@
 namespace :async_cache do
+  prereqs =
+    if defined?(Rails)
+      [:environment]
+    else
+      []
+    end
+
   desc 'Clear the worker queues'
-  task :clear do
+  task :clear => prereqs do
     AsyncCache::Store.stores.each do |store|
       store.clear
+      puts "Cleared #{store.inspect}"
     end
   end
 end

--- a/lib/async_cache/workers/active_job.rb
+++ b/lib/async_cache/workers/active_job.rb
@@ -11,6 +11,10 @@ module AsyncCache
         true
       end
 
+      def self.clear
+        raise NotImplementedError, 'ActiveJob does not support clearing queues'
+      end
+
       def self.enqueue_async_job(key:, version:, expires_in:, block:, arguments:)
         self.perform_later key, version, expires_in, arguments, block
       end

--- a/lib/async_cache/workers/base.rb
+++ b/lib/async_cache/workers/base.rb
@@ -23,6 +23,11 @@ module AsyncCache
         raise NotImplementedError
       end
 
+      # Clear the active jobs from this worker's queue.
+      def self.clear
+        raise NotImplementedError
+      end
+
       # Public interface for enqueuing jobs. This is what is called by
       # {AsyncCache::Store}.
       def self.enqueue_async_job(key:, version:, expires_in:, block:, arguments:)

--- a/lib/async_cache/workers/sidekiq.rb
+++ b/lib/async_cache/workers/sidekiq.rb
@@ -13,21 +13,31 @@ module AsyncCache
       # Use the Sidekiq API to see if there are worker processes available to
       # handle the async cache jobs queue.
       def self.has_workers?
-        target_queue = self.sidekiq_options['queue'].to_s
-
         processes = Sidekiq::ProcessSet.new.to_a
         queues_being_processed = processes.flat_map { |p| p['queues'] }
 
-        if queues_being_processed.include? target_queue
+        if queues_being_processed.include? sidekiq_queue
           true
         else
           false
         end
       end
 
+      def self.clear
+        queue = Sidekiq::Queue.new sidekiq_queue
+
+        queue.clear
+      end
+
       def self.enqueue_async_job(key:, version:, expires_in:, block:, arguments:)
         self.perform_async key, version, expires_in, arguments, block
       end
+
+      private
+
+        def self.sidekiq_queue
+          self.sidekiq_options['queue'].to_s
+        end
 
     end # class SidekiqWorker
   end

--- a/spec/railtie_spec.rb
+++ b/spec/railtie_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe AsyncCache do
+  context 'Railtie' do
+    class Application < Rails::Application
+    end
+
+    before(:all) do
+      app = Application.new
+      app.load_tasks
+    end
+
+    it 'adds the async_cache:* tasks' do
+      expect(Rake::Task.task_defined?('async_cache:clear')).to eq true
+    end
+  end
+end

--- a/spec/tasks_spec.rb
+++ b/spec/tasks_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe AsyncCache do
+  context 'tasks' do
+    before(:all) do
+      require 'rake'
+      Rake.application.clear
+      Rake.application.add_import File.join(File.dirname(__FILE__), '../lib/async_cache/tasks/clear.rake')
+      Rake.application.load_imports
+    end
+
+    before(:each) do
+      # Reset the array of known store instances
+      AsyncCache::Store.instance_eval { @stores = [] }
+    end
+
+    describe ':clear' do
+      it 'clears with worker queues' do
+        store = AsyncCache::Store.new backend: Rails.cache, worker: :sidekiq
+
+        queue_double = double 'Sidekiq::Queue'
+        allow(Sidekiq::Queue).to receive(:new).and_return(queue_double)
+
+        expect(queue_double).to receive(:clear)
+
+        Rake.application['async_cache:clear'].execute
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a `async_cache:clear` Rake task (which can be auto-loaded via a Railtie) to clear the queues.
